### PR TITLE
Add _join method + CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,13 +4,13 @@
 #  codecov-action: https://github.com/codecov/codecov-action
 
 name: CI
-on: workflow_dispatch
-    #  push:
-    #    branches:
-    #      - "*"
-    #  pull_request:
-    #    branches:
-    #      - "*"
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,14 +4,13 @@
 #  codecov-action: https://github.com/codecov/codecov-action
 
 name: CI
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+on: workflow_dispatch
+    #  push:
+    #    branches:
+    #      - "*"
+    #  pull_request:
+    #    branches:
+    #      - "*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,52 @@
+# This uses actios:
+#  checkout: https://github.com/actions/checkout
+#  cache: https://github.com/actions/cache
+#  codecov-action: https://github.com/codecov/codecov-action
+
+name: CI
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (${{ matrix.python-version }} | ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+          os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          cache-downloads: true
+          cache-environment: true
+          micromamba-version: "latest"
+          environment-file: ci/environment.yaml
+          create-args: python=${{ matrix.python-version }}
+      - name: Install ufs2arco
+        shell: micromamba-shell {0}
+        run: |
+          python -V
+          python -c "import setuptools; print(setuptools.__version__)"
+          python -m pip install -e . --no-deps
+      - name: Run Unit Tests
+        shell: bash -l {0}
+        run: |
+          python -V
+          coverage run --rcfile=coverage.toml -m pytest --verbose
+      - name: Get coverage report
+        shell: bash -l {0}
+        run: |
+          coverage report -m ; coverage xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@
 
 name: CI
 on:
+  workflow_dispatch:
   push:
     branches:
       - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,13 @@ on:
   pull_request:
     branches:
       - "*"
+  workflow_dispatch:
+    logLevel:
+      options:
+        - info
+        - warning
+        - debug
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
@@ -35,8 +42,9 @@ jobs:
           micromamba-version: "latest"
           environment-file: environment.yaml
           create-args: python=${{ matrix.python-version }}
+          init-shell: bash
       - name: Install ufs2arco
-        shell: micromamba-shell {0}
+        shell: bash -l {0}
         run: |
           python -V
           python -c "import setuptools; print(setuptools.__version__)"
@@ -48,5 +56,40 @@ jobs:
           coverage run --rcfile=coverage.toml -m pytest --verbose
       - name: Get coverage report
         shell: bash -l {0}
+        run: |
+          coverage report -m ; coverage xml
+
+  windows-build:
+    name: Build (${{ matrix.python-version }} | ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest"]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          cache-downloads: true
+          cache-environment: true
+          micromamba-version: "latest"
+          environment-file: environment.yaml
+          create-args: python=${{ matrix.python-version }}
+          init-shell: powershell
+      - name: Install ufs2arco
+        shell: pwsh
+        run: |
+          python -V
+          python -c "import setuptools; print(setuptools.__version__)"
+          python -m pip install -e . --no-deps
+      - name: Run Unit Tests
+        shell: pwsh
+        run: |
+          python -V
+          coverage run --rcfile=coverage.toml -m pytest --verbose
+      - name: Get coverage report
+        shell: pwsh
         run: |
           coverage report -m ; coverage xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
           cache-downloads: true
           cache-environment: true
           micromamba-version: "latest"
-          environment-file: ci/environment.yaml
+          environment-file: environment.yaml
           create-args: python=${{ matrix.python-version }}
       - name: Install ufs2arco
         shell: micromamba-shell {0}

--- a/coverage.toml
+++ b/coverage.toml
@@ -1,0 +1,5 @@
+[tool.coverage.run]
+omit = [
+    "tests/*.py",
+    "**/__init__.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ source="https://github.com/NOAA-PSL/ufs2arco"
 documentation="https://ufs2arco.readthedocs.io/en/latest/"
 
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=64.0.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/tests/config-replay.yaml
+++ b/tests/config-replay.yaml
@@ -1,0 +1,84 @@
+FV3Dataset:
+    file_prefixes:
+        - bfg_
+        - sfg_
+
+    path_out       : "gcs://noaa-ufs-gefsv13replay/ufs-hr1/0.25-degree/03h-freq/zarr/"
+    coords_path_out: "gcs://noaa-ufs-gefsv13replay/ufs-hr1/0.25-degree/coordinates/zarr/"
+    forecast_hours  : [0, 3]
+
+    chunks_in:
+        # estimated 37MB per chunk (the full 3D field)
+        time        : 1
+        pfull       : 127
+        grid_yt     : 768
+        grid_xt     : 1536
+
+    chunks_out:
+        time        : 1
+        pfull       : 127
+        grid_yt     : 768
+        grid_xt     : 1536
+
+    coords:
+        - phalf
+        - pfull
+        - grid_xt
+        - grid_yt
+        - ak
+        - bk
+
+    data_vars:
+        # 3D atmospheric vars
+        - tmp
+        - ugrd
+        - vgrd
+        - delz
+        - dzdt
+        - dpres
+        - spfh
+        - o3mr
+        # 3D land vars
+        - soilt1
+        - soilt2
+        - soilt3
+        - soilt4
+        - soill1
+        - soill2
+        - soill3
+        - soill4
+        - soilw1
+        - soilw2
+        - soilw3
+        - soilw4
+        # 2D vars
+        - snod
+        - prateb_ave
+        - pressfc
+        - weasd
+        - f10m
+        - sfcr
+        # Surface forcing vars
+        - land
+        - vtype
+        - sotyp
+        - veg
+        - icec
+        - tmpsfc
+        # For TOA solar radiation
+        - dswrf_avetoa
+        - ulwrf_avetoa
+        - uswrf_avetoa
+        # Ease comparison
+        - tmp2m
+        - ugrd10m
+        - vgrd10m
+        # For cloudy assimilation
+        - clwmr
+        - grle
+        - icmr
+        - rwmr
+        - snmr
+        # For future operational implementation
+        - ntrnc
+        - nicp

--- a/tests/test_ufsdataset.py
+++ b/tests/test_ufsdataset.py
@@ -1,0 +1,21 @@
+import pytest
+
+from os.path import join, dirname
+
+from ufs2arco import FV3Dataset
+
+
+@pytest.mark.parametrize(
+    "prefix", ["gcs://", "s3://", "https://", "/contrib", "/scratch/"]
+)
+def test_join_cloud(prefix):
+
+    dummy_path = lambda p : str(p)
+    fname = join(dirname(__file__), "config-replay.yaml")
+    ufs = FV3Dataset(dummy_path, fname)
+
+    path = ufs._join(prefix, "directory", "fv3.zarr")
+    if "://" in prefix:
+        assert path == f"{prefix}directory/fv3.zarr"
+    else:
+        assert path == join(prefix, "directory", "fv3.zarr")

--- a/ufs2arco/ufsdataset.py
+++ b/ufs2arco/ufsdataset.py
@@ -366,17 +366,23 @@ class UFSDataset:
         return xftime
 
     @staticmethod
-    def _join(a, b):
+    def _join(a, *p):
         """System independent join operation"""
         clouds = ("gcs://", "s3://", "https://")
-        if any(x in a for x in clouds) or any(x in b for x in clouds):
+        if any(x in a for x in clouds) or any(any(x in this_path for x in clouds) for this_path in p):
             try:
-                assert isinstance(a, str) and isinstance(b, str)
+                assert isinstance(a, str) and all(isinstance(this_path, str) for this_path in p)
             except:
-                raise TypeError(f"For cloud storage, paths need to be strings. Tried to join {type(a)} and {type(b)}")
+                raise TypeError(f"For cloud storage, paths need to be strings.")
 
-            join_char = "/" if a[-1] != "/" and b[0] != "/" else ""
-            return f"{a}{join_char}{b}"
+            path = a
+            join_char = "/" if a[-1] != "/" else ""
+            for this_path in p:
+                path += join_char
+                path += this_path
+                join_char = "/" if this_path[-1] != "/" else ""
+
+            return path
 
         else:
-            return join(a, b)
+            return join(a, *p)


### PR DESCRIPTION
We've run into simple path related bugs more than once due to the fact that we are running code on different operating systems (*nix vs windows) but sometimes the paths we create are actually for the cloud. This means that `os.path.join` does not always work. I've recently found that `Pathlib` also does not work for the cloud because it converts`//`->`/` from e.g. `s3://` or `https://`.

Example: 
Windows user wants to read from bucket `s3://mybucket/fv3.zarr`. `os.path.join` turns this into `s3:\\mybucket\fv3.zarr` (or something, I don't know windows) 

On linux if we were using Pathlib to read from that bucket, the path would become `s3:/mybucket/fv3.zarr`

So this PR makes `UFSDataset` recognize `s3://`, `gcs://` or `https://` paths and treats them properly, otherwise deferring to `os.path.join`.

Also, this adds a simple unit test to make sure the join operation is correct as well as a CI workflow to test this on linux, macos, and windows.