### PR TITLE
Generalize ReplayMover

### DIFF
--- a/examples/replay/config-0.25-degree.yaml
+++ b/examples/replay/config-0.25-degree.yaml
@@ -7,6 +7,16 @@ FV3Dataset:
     coords_path_out: "gcs://noaa-ufs-gefsv13replay/ufs-hr1/0.25-degree/coordinates/zarr/"
     forecast_hours  : [0, 3]
 
+    cycles:
+        start       : "1994-01-01T00"
+        end         : "2023-10-13T06"
+        freq        : "6h"
+
+    time:
+        start       : "1993-12-31T18"
+        end         : "2023-10-13T03"
+        freq        : "3h"
+
     chunks_out:
         time        : 1
         pfull       : 1

--- a/examples/replay/config-1.00-degree.yaml
+++ b/examples/replay/config-1.00-degree.yaml
@@ -7,6 +7,16 @@ FV3Dataset:
     coords_path_out: "gcs://noaa-ufs-gefsv13replay/ufs-hr1/1.00-degree/coordinates/zarr/"
     forecast_hours  : [0, 3]
 
+    cycles:
+        start       : "1994-01-01T00"
+        end         : "1999-06-13T06"
+        freq        : "6h"
+
+    time:
+        start       : "1993-12-31T18"
+        end         : "1999-06-13T03"
+        freq        : "3h"
+
     chunks_in:
         # estimated 37MB per chunk (the full 3D field)
         time        : 1

--- a/examples/replay/move_one_degree.py
+++ b/examples/replay/move_one_degree.py
@@ -20,6 +20,7 @@ def submit_slurm_mover(job_id, mover):
         f"    config_filename='{mover.config_filename}',\n"+\
         f"    storage_options={mover.storage_options},\n"+\
         f"    main_cache_path='{mover.main_cache_path}',\n"+\
+        f"    component='{mover.component}',\n"+\
         f")\n"+\
         f"mover.run({job_id})"
 
@@ -62,6 +63,7 @@ if __name__ == "__main__":
         config_filename="config-1.00-degree.yaml",
         storage_options={"token": "/contrib/Tim.Smith/.gcs/replay-service-account.json"},
         main_cache_path="/lustre/Tim.Smith/tmp-replay/1.00-degree",
+        component="fv3",
     )
 
     localtime.start("Make and Store Container Dataset")

--- a/examples/replay/move_quarter_degree.py
+++ b/examples/replay/move_quarter_degree.py
@@ -20,6 +20,7 @@ def submit_slurm_mover(job_id, mover):
         f"    config_filename='{mover.config_filename}',\n"+\
         f"    storage_options={mover.storage_options},\n"+\
         f"    main_cache_path='{mover.main_cache_path}',\n"+\
+        f"    component='{mover.component}',\n"+\
         f")\n"+\
         f"mover.run({job_id})"
 
@@ -62,6 +63,7 @@ if __name__ == "__main__":
         config_filename="config-0.25-degree.yaml",
         storage_options={"token": "/contrib/Tim.Smith/.gcs/replay-service-account.json"},
         main_cache_path="/lustre/Tim.Smith/tmp-replay/0.25-degree",
+        component="fv3",
     )
 
     localtime.start("Make and Store Container Dataset")

--- a/examples/replay/replay_mover.py
+++ b/examples/replay/replay_mover.py
@@ -12,19 +12,9 @@ import xarray as xr
 import dask.array as darray
 from zarr import NestedDirectoryStore
 
-from ufs2arco import FV3Dataset, Timer
+from ufs2arco import FV3Dataset, MOM6Dataset, CICE6Dataset, Timer
 
 class ReplayMover1Degree():
-    """
-
-    Note:
-        Currently this makes the unnecessary but easy-to-implement assumption that we want forecast_hours 0 & 3.
-        This assumption is key to the hard coded end date and timedelta used to make :attr:`xtime`.
-        It should also be confirmed that this assumption does not impact the "ftime" variable, that is right now
-        being created in the container dataset. The values should be overwritten when the data are actually
-        generated, but who knows.
-    """
-
 
     n_jobs = None
 
@@ -33,22 +23,18 @@ class ReplayMover1Degree():
 
     @property
     def xcycles(self):
-        """These are the DA cycle timestamps, which are every 6 hours. There is one s3 directory per cycle for replay."""
-        cycles = pd.date_range(start="1994-01-01", end="1999-06-13T06:00:00", freq="6h")
-        return xr.DataArray(cycles, coords={"cycles": cycles}, dims="cycles")
+        return xr.DataArray(self.cycles, coords={"cycles": cycles}, dims="cycles")
 
 
     @property
     def xtime(self):
-        """These are the time stamps of the resulting dataset, assuming we are grabbing fhr00 and fhr03.
+        """These are the time stamps of the resulting dataset.
 
         This was created by processing a few DA cycles with the desired forecast hours, and figuring out
         operations were needed to map from a list of all DA cycles to the resulting ``"time"``
         array in the final dataset.
         """
-        time = pd.date_range(start="1994-01-01", end="1999-06-13T09:00:00", freq="3h")
-        iau_time = time - timedelta(hours=6)
-        return xr.DataArray(iau_time, coords={"time": iau_time}, dims="time", attrs={"long_name": "time", "axis": "T"})
+        return xr.DataArray(self.time, coords={"time": self.time}, dims="time", attrs={"long_name": "time", "axis": "T"})
 
 
     @property
@@ -120,8 +106,30 @@ class ReplayMover1Degree():
         name = f"{component.upper()}Dataset" # i.e., FV3Dataset ... maybe an unnecessary generalization at this stage
         self.forecast_hours = config[name]["forecast_hours"]
         self.file_prefixes = config[name]["file_prefixes"]
+        self.cycles = pd.date_range(**config[name]["cycles"])
+        self.time = pd.date_range(**config[name]["time"])
 
-        assert tuple(self.forecast_hours) == (0, 3)
+        if component.lower() == "fv3":
+            self.Dataset = FV3Dataset
+            self.cached_path = self.fv3_path
+        elif component.lower() == "mom6":
+            self.Dataset = MOM6Dataset
+            self.cached_path = self.mom6_path
+        elif component.lower() == "cice6":
+            self.Dataset = CICE6Dataset
+            self.cached_path = self.cice6_path
+
+        # for move_single_dataset, we have to figure out how many resulting timestamps we have
+        # within a single DA cycle
+        try:
+            assert "freq" in pd.date_range(config[name]["cycles"])
+            assert "freq" in pd.date_range(config[name]["time"])
+
+        except:
+            raise KeyError("ReplayMover.__init__: we need 'freq' inside the config 'cycles' and 'time' sections")
+        delta_t_cycle = pd.Timedelta(config[name]["cycles"]["freq"])
+        delta_t_time  = pd.Timedelta(config[name]["time"]["freq"])
+        self.n_steps_per_cycle = delta_t_cycle // delta_t_time
 
 
     def run(self, job_id):
@@ -156,17 +164,16 @@ class ReplayMover1Degree():
     def move_single_dataset(self, job_id, cycle):
         """Store a single cycle to zarr"""
 
-        replay = FV3Dataset(path_in=self.cached_path, config_filename=self.config_filename)
+        replay = self.Dataset(path_in=self.cached_path, config_filename=self.config_filename)
         xds = replay.open_dataset(cycle, **self.ods_kwargs(job_id))
 
         index = list(self.xtime.values).index(xds.time.values[0])
-        tslice = slice(index, index+2)
+        tslice = slice(index, index+self.n_steps_per_cycle)
 
+        spatial_region = {k: slice(None, None) for k in xds.dims if k != "time"}
         region = {
             "time": tslice,
-            "pfull": slice(None, None),
-            "grid_yt": slice(None, None),
-            "grid_xt": slice(None, None),
+            **spatial_region,
         }
         region = {k : v for k,v in region.items() if k in xds.dims}
 
@@ -187,7 +194,7 @@ class ReplayMover1Degree():
 
         localtime = Timer()
 
-        replay = FV3Dataset(path_in=self.cached_path, config_filename=self.config_filename)
+        replay = self.Dataset(path_in=self.cached_path, config_filename=self.config_filename)
 
         localtime.start("Reading Single Dataset")
         cycle = self.my_cycles(0)[0]
@@ -241,7 +248,7 @@ class ReplayMover1Degree():
 
 
     @staticmethod
-    def cached_path(dates, forecast_hours, file_prefixes):
+    def fv3_path(dates, forecast_hours, file_prefixes):
         """This is passed to :class:`FV3Dataset`, and it generates the paths to read from for the given inputs
 
         Note:
@@ -286,6 +293,46 @@ class ReplayMover1Degree():
                     files.append(this_file)
         return [join(upper, this_file) for this_file in files]
 
+    @staticmethod
+    def mom6_path(dates, forecast_hours, file_prefixes):
+        """This is passed to :class:`MOM6Dataset`, and it generates the paths to read from for the given inputs
+
+        Note:
+            With simplecache it's not clear where the cached files go, and they
+            do not clear until the process is done running (maybe?) which can file up a filesystem easily.
+            So we use filecache instead.
+
+        Args:
+            dates (Iterable[datetime]): with the DA cycles to read from
+            forecast_hours (List[int]): with the forecast hours to grab ... note here we assume [0, 3] ... but don't enforce it here
+            file_prefixes (List[str]): e.g. ["sfg_", "bfg_"]
+
+        Returns:
+            list_of_paths (List[str]): see example
+
+        Example:
+            >>> mover = ReplayMover( ... )
+            >>> mover.cached_path(
+                    dates=[datetime(1994,1,1,0), datetime(1994,1,1,6)],
+                    forecast_hours=[0],
+                    file_prefixes=["ocn_"],
+                )
+				['filecache::s3://noaa-ufs-gefsv13replay-pds/1deg/1994/01/1994010100/ocn_1994_01_01_00.nc',
+                'filecache::s3://noaa-ufs-gefsv13replay-pds/1deg/1994/01/1994010106/ocn_1994_01_01_06.nc']
+        """
+        upper = "filecache::s3://noaa-ufs-gefsv13replay-pds/1deg"
+        dates = [dates] if not isinstance(dates, Iterable) else dates
+
+        files = []
+        for date in dates:
+            this_dir = f"{date.year:04d}/{date.month:02d}/{date.year:04d}{date.month:02d}{date.day:02d}{date.hour:02d}"
+            for fp in file_prefixes:
+                for fhr in forecast_hours:
+					this_date = cycle+timedelta(hours=fhr)
+                    this_file = f"{this_dir}/{fp}{this_date.year:04d}_{this_date.month:02d}_{this_date.day:02d}_{this_date.hour:02d}.nc"
+                    files.append(this_file)
+        return [join(upper, this_file) for this_file in files]
+
 
     @staticmethod
     def npdate2datetime(npdate):
@@ -320,18 +367,17 @@ class ReplayMover1Degree():
                 del single[key]
         return single
 
-    @staticmethod
-    def add_time_coords(xds, time2cftime):
+    def add_time_coords(self, xds, time2cftime):
         """add ftime and cftime to container
 
         This is a bit dirty, passing a static method from another class as a function arg... so it goes.
         """
+
+        iau_offset = -6 if self.component == "fv3" else 0
+        repeater = tuple(np.timedelta64(timedelta(hours=fhr-iau_offset)) for fhr in self.forecast_hours)
         ftime = np.array(
-                [
-                    (np.timedelta64(timedelta(hours=-6)), np.timedelta64(timedelta(hours=-3)))
-                        for _ in range(len(xds["time"])//2)
-                    ]
-                ).flatten()
+            [repeater for _ in range(len(xds["time"])//len(repeater)],
+        ).flatten()
 
         xds["ftime"] = xr.DataArray(
                 ftime,
@@ -359,20 +405,6 @@ class ReplayMover1Degree():
 
 class ReplayMoverQuarterDegree(ReplayMover1Degree):
 
-    @property
-    def xcycles(self):
-        """These are the DA cycle timestamps, which are every 6 hours. There is one s3 directory per cycle for replay."""
-        cycles = pd.date_range(start="1994-01-01", end="2023-10-13T06:00:00", freq="6h")
-        return xr.DataArray(cycles, coords={"cycles": cycles}, dims="cycles")
-
-
-    @property
-    def xtime(self):
-        """These are the time stamps of the resulting dataset, assuming we are grabbing fhr00 and fhr03"""
-        time = pd.date_range(start="1994-01-01", end="2023-10-13T09:00:00", freq="3h")
-        iau_time = time - timedelta(hours=6)
-        return xr.DataArray(iau_time, coords={"time": iau_time}, dims="time", attrs={"long_name": "time", "axis": "T"})
-
     def __init__(
         self,
         n_jobs,
@@ -390,7 +422,7 @@ class ReplayMoverQuarterDegree(ReplayMover1Degree):
         )
 
     @staticmethod
-    def cached_path(dates, forecast_hours, file_prefixes):
+    def fv3_path(dates, forecast_hours, file_prefixes):
         upper = "filecache::s3://noaa-ufs-gefsv13replay-pds"
         dates = [dates] if not isinstance(dates, Iterable) else dates
 
@@ -400,5 +432,20 @@ class ReplayMoverQuarterDegree(ReplayMover1Degree):
             for fp in file_prefixes:
                 for fhr in forecast_hours:
                     this_file = join(this_dir, f"{fp}{date.year:04d}{date.month:02d}{date.day:02d}{date.hour:02d}_fhr{fhr:02d}_control")
+                    files.append(this_file)
+        return [join(upper, this_file) for this_file in files]
+
+    @staticmethod
+    def mom6_path(dates, forecast_hours, file_prefixes):
+        upper = "filecache::s3://noaa-ufs-gefsv13replay-pds"
+        dates = [dates] if not isinstance(dates, Iterable) else dates
+
+        files = []
+        for date in dates:
+            this_dir = f"{date.year:04d}/{date.month:02d}/{date.year:04d}{date.month:02d}{date.day:02d}{date.hour:02d}"
+            for fp in file_prefixes:
+                for fhr in forecast_hours:
+                    this_date = cycle+timedelta(hours=fhr)
+                    this_file = f"{this_dir}/{fp}{this_date.year:04d}_{this_date.month:02d}_{this_date.day:02d}_{this_date.hour:02d}.nc"
                     files.append(this_file)
         return [join(upper, this_file) for this_file in files]


### PR DESCRIPTION
This should generalize ReplayMover in the following ways:

1. create a `Dataset` attribute the depends on the `component` initialization argument, rather than explicitly calling `FV3Dataset` (e.g., in ReplayMover.move_single_dataset
2. create the `xcycles` and `xtime` properties more generally, by creating the vectors based on inputs in the config yaml file
3. remove assumptions that `forecast_hours == (0, 3)`:
    * in move_single_dataset, no longer set `tslice` to be `slice(index, index+2)`, but figure out what 2 should be more generally in __init__ (this is attribute n_steps_per_cycle
    * in the really dirty helper method `add_time_coords`, recreate the `ftime` vector more generally. this may need some attention if we do actually have an ocean/ice IAU, but I don't think anyone does that
4. rename the staticmethod `cached_path` -> `fv3_path` and create a similar one for mom6_path