### PR TITLE
Timer.now method

### DIFF
--- a/ufs2arco/timer.py
+++ b/ufs2arco/timer.py
@@ -54,6 +54,14 @@ class Timer:
             self._print(f"{mytitle}: {elapsed_time:.4f} seconds\n")
         return float(elapsed_time)
 
+    def now(self):
+        """Return the time elapsed since timer was started, without stopping the timer
+
+        Returns:
+            (float): elapsed time in seconds
+        """
+        return float(self.get_elapsed())
+
     def _print(self, *args, **kwargs):
         """Print the timing to :attr:`filename` if specified, or to screen.
 


### PR DESCRIPTION
As discussed in #19 this adds the `.now()` method as featured here:

![Screen Shot 2024-06-03 at 11 10 50 AM](https://github.com/NOAA-PSL/ufs2arco/assets/28659578/addec9d5-ac61-452a-a9a0-7dc4581b5772)

Sorry again for the quick merge @danielabdi-noaa ! 