### PR TITLE
Reset Coords in Layers2Pressure.calc_geopotential

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ufs2arco"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tools for converting Unified Forecast System (UFS) output to Analysis Ready, Cloud Optimized (ARCO) format"
 authors = [
     {name="Timothy Smith", email="tim.smith@noaa.gov"},

--- a/ufs2arco/__init__.py
+++ b/ufs2arco/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from .cice6dataset import CICE6Dataset
 from .fv3dataset import FV3Dataset

--- a/ufs2arco/layers2pressure.py
+++ b/ufs2arco/layers2pressure.py
@@ -243,11 +243,13 @@ class Layers2Pressure():
         # Geopotential at the surface
         phi0 = self.g * hgtsfc
         phi0 = phi0.expand_dims({"kp1": [len(self.pfull)]})
+        phi0 = phi0.reset_coords(drop=True)
 
         # Concatenate, cumulative sum from the ground to TOA
         dz = self.g*np.abs(delz)
         dz["kp1"] = kp1_left.sel({self.level_name: delz[self.level_name]})
         dz = dz.swap_dims({self.level_name: "kp1"}).drop_vars(self.level_name)
+        dz = dz.reset_coords(drop=True)
 
         phii = xr.concat([dz,phi0], dim="kp1")
 


### PR DESCRIPTION
The coordinates in phi0 and dz need to be dropped in order for the concatenation to work properly.