### PR TITLE
Some fixes for anemoi integration

### DIFF
--- a/ufs2arco/__init__.py
+++ b/ufs2arco/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 from .cice6dataset import CICE6Dataset
 from .fv3dataset import FV3Dataset

--- a/ufs2arco/datamover.py
+++ b/ufs2arco/datamover.py
@@ -222,10 +222,12 @@ class DataMover():
             # allow these encoding keys to pass to the container creation
             # this basically allows us to control datetime objects, which
             # really is only necessary for anemoi
-            for key in ["dtype", "units"]:
-                if key in xds[varname].encoding and xds[varname].attrs.get("use_source_encoding", False):
-                    nds[varname].encoding[key] = xds[varname].encoding[key]
-                    logger.info(f"{self.name}.create_container: passing '{varname}' encoding['{key}'] to container")
+            if xds[varname].attrs.get("use_source_encoding", False):
+                for key in ["dtype", "units"]:
+                    if key in xds[varname].encoding:
+                        nds[varname].encoding[key] = xds[varname].encoding[key]
+                        logger.info(f"{self.name}.create_container: passing '{varname}' encoding['{key}'] to container")
+                nds[varname].attrs.pop("use_source_encoding")
 
         nds.to_zarr(self.target.store_path, compute=False, **kwargs)
         logger.info(f"{self.name}.create_container: stored container at {self.target.store_path}\n{nds}\n")

--- a/ufs2arco/datamover.py
+++ b/ufs2arco/datamover.py
@@ -219,6 +219,14 @@ class DataMover():
                 attrs=xds[varname].attrs.copy(),
             )
 
+            # allow these encoding keys to pass to the container creation
+            # this basically allows us to control datetime objects, which
+            # really is only necessary for anemoi
+            for key in ["dtype", "units"]:
+                if key in xds[varname].encoding and xds[varname].attrs.get("use_source_encoding", False):
+                    nds[varname].encoding[key] = xds[varname].encoding[key]
+                    logger.info(f"{self.name}.create_container: passing '{varname}' encoding['{key}'] to container")
+
         nds.to_zarr(self.target.store_path, compute=False, **kwargs)
         logger.info(f"{self.name}.create_container: stored container at {self.target.store_path}\n{nds}\n")
 

--- a/ufs2arco/datamover.py
+++ b/ufs2arco/datamover.py
@@ -219,16 +219,6 @@ class DataMover():
                 attrs=xds[varname].attrs.copy(),
             )
 
-            # allow these encoding keys to pass to the container creation
-            # this basically allows us to control datetime objects, which
-            # really is only necessary for anemoi
-            if xds[varname].attrs.get("use_source_encoding", False):
-                for key in ["dtype", "units"]:
-                    if key in xds[varname].encoding:
-                        nds[varname].encoding[key] = xds[varname].encoding[key]
-                        logger.info(f"{self.name}.create_container: passing '{varname}' encoding['{key}'] to container")
-                nds[varname].attrs.pop("use_source_encoding")
-
         nds.to_zarr(self.target.store_path, compute=False, **kwargs)
         logger.info(f"{self.name}.create_container: stored container at {self.target.store_path}\n{nds}\n")
 

--- a/ufs2arco/driver.py
+++ b/ufs2arco/driver.py
@@ -216,6 +216,5 @@ class Driver:
             # just in case
             zarr.consolidate_metadata(target.store_path)
         topo.barrier()
-        logger.info(f"Done storing global attributes\n")
 
         logger.info(f"🚀🚀🚀 Dataset is ready for launch at: {target.store_path}")

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -35,6 +35,7 @@ class Anemoi(Target):
     resolution = None
     use_level_index = False
     allow_nans = True
+    data_dtype = np.float32
 
     # these are basically properties
     base_dims = ("variable", "cell")
@@ -350,7 +351,11 @@ class Anemoi(Target):
 
         data_vars = xr.concat(
             [
-                xds[name].expand_dims({"variable": [this_channel]})
+                xds[name].expand_dims(
+                    {"variable": [this_channel]},
+                ).astype(
+                    self.data_dtype,
+                )
                 for this_channel, name in zip(channel, varlist)
             ],
             dim="variable",

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -421,15 +421,16 @@ class Anemoi(Target):
         xds = xr.open_zarr(self.store_path)
 
         # first load up the arrays
-        for key in [
+        stat_vars = [
             "count_array",
             "has_nans_array",
             "maximum_array",
             "minimum_array",
             "squares_array",
             "sums_array",
-        ]:
-            xds[key] = xds[key].load()
+        ]
+        xds = xds[stat_vars]
+        xds = xds.load()
 
         logger.info(f"{self.name}.aggregate_stats: Loaded temporary stats arrays")
 


### PR DESCRIPTION
Fix up a few details so that we can train, and some other nice features including

- [x] consistent `dates` dtype (i.e., solves #41)
- [x] when aggregating statistics, load these small arrays first before computation (much faster)
- [x] when aggregating statistics, don't re-append the whole data array (or at least make it explicit that this isn't happening
- [x] Successful graph creation
- [x] Successful training config validation
- [x] Training has successfully started