### PR TITLE
Revamp Level Selection

### DIFF
--- a/tests/integration/gefs.anemoi.yaml
+++ b/tests/integration/gefs.anemoi.yaml
@@ -36,12 +36,13 @@ source:
     - 500
     - 1000
 
-target:
-  name: anemoi
-
   slices:
     sel:
       latitude: [89.5, -89.5]
+
+
+target:
+  name: anemoi
 
   forcings:
     - cos_latitude

--- a/tests/integration/gefs.serial.yaml
+++ b/tests/integration/gefs.serial.yaml
@@ -37,14 +37,14 @@ source:
     - 500
     - 1000
 
+  slices:
+    sel:
+      latitude: [89.5, -89.5]
+
 target:
   name: forecast
   rename:
     level: pressure
-
-  slices:
-    sel:
-      latitude: [89.5, -89.5]
 
   chunks:
     t0: 1

--- a/ufs2arco/sources/analysis.py
+++ b/ufs2arco/sources/analysis.py
@@ -38,6 +38,7 @@ class AnalysisSource(Source):
         variables: Optional[list | tuple] = None,
         levels: Optional[list | tuple] = None,
         use_nearest_levels: Optional[bool] = False,
+        slices: Optional[dict] = None,
     ) -> None:
         """
         Initialize the Source object.
@@ -48,12 +49,14 @@ class AnalysisSource(Source):
             levels (list, tuple, optional): vertical levels to grab
             use_nearest_levels (bool, optional): if True, all level selection with
                 ``xarray.Dataset.sel(level=levels, method="nearest")``
+            slices (dict, optional): either "sel" or "isel", with slice, passed to xarray
         """
         self.time = pd.date_range(**time)
         super().__init__(
             variables=variables,
             levels=levels,
             use_nearest_levels=use_nearest_levels,
+            slices=slices,
         )
 
     def open_sample_dataset(

--- a/ufs2arco/sources/aws_gefs_archive.py
+++ b/ufs2arco/sources/aws_gefs_archive.py
@@ -105,6 +105,7 @@ class AWSGEFSArchive(EnsembleForecastSource):
                 else:
                     dsdict[varname] = xr.DataArray(name=varname)
         xds = xr.Dataset(dsdict)
+        xds = self.apply_slices(xds)
         return xds
 
     def _open_single_variable(
@@ -149,7 +150,7 @@ class AWSGEFSArchive(EnsembleForecastSource):
                     xds = xds.drop_vars(key)
         else:
 
-            if "level" in xds:
+            if "level" in xds and self.levels is not None:
                 level_selection = [l for l in self.levels if l in xds.level.values]
                 if len(level_selection) == 0:
                     return xr.DataArray(name=varname)

--- a/ufs2arco/sources/ensemble_forecast.py
+++ b/ufs2arco/sources/ensemble_forecast.py
@@ -40,6 +40,7 @@ class EnsembleForecastSource(Source):
         variables: Optional[list | tuple] = None,
         levels: Optional[list | tuple] = None,
         use_nearest_levels: Optional[bool] = False,
+        slices: Optional[dict] = None,
     ) -> None:
         """
         Initialize the Source object.
@@ -52,6 +53,7 @@ class EnsembleForecastSource(Source):
             levels (list, tuple, optional): vertical levels to grab
             use_nearest_levels (bool, optional): if True, all level selection with
                 ``xarray.Dataset.sel(level=levels, method="nearest")``
+            slices (dict, optional): either "sel" or "isel", with slice, passed to xarray
         """
         self.t0 = pd.date_range(**t0)
         self.fhr = np.arange(fhr["start"], fhr["end"] + 1, fhr["step"])
@@ -60,6 +62,7 @@ class EnsembleForecastSource(Source):
             variables=variables,
             levels=levels,
             use_nearest_levels=use_nearest_levels,
+            slices=slices,
         )
 
 

--- a/ufs2arco/sources/gcs_era5_1degree.py
+++ b/ufs2arco/sources/gcs_era5_1degree.py
@@ -74,7 +74,9 @@ class GCSERA5OneDegree(AnalysisSource):
 
         # select
         xds = xds[self.variables]
-        xds = xds.sel(level=self.levels, **self._level_sel_kwargs)
+        if self.levels is not None:
+            xds = xds.sel(level=self.levels, **self._level_sel_kwargs)
+        xds = self.apply_slices(xds)
 
         # set
         self._xds = xds

--- a/ufs2arco/sources/gcs_replay_atmosphere.py
+++ b/ufs2arco/sources/gcs_replay_atmosphere.py
@@ -44,6 +44,7 @@ class GCSReplayAtmosphere(AnalysisSource):
         variables: Optional[list | tuple] = None,
         levels: Optional[list | tuple] = None,
         use_nearest_levels: Optional[bool] = False,
+        slices: Optional[dict] = None,
     ) -> None:
 
         # open and rename
@@ -59,11 +60,14 @@ class GCSReplayAtmosphere(AnalysisSource):
             variables=variables,
             levels=levels,
             use_nearest_levels=use_nearest_levels,
+            slices=slices,
         )
 
         # now subsample the dataset
         self._xds = self._xds[self.variables]
-        self._xds = self._xds.sel(level=self.levels, **self._level_sel_kwargs)
+        if self.levels is not None:
+            self._xds = self._xds.sel(level=self.levels, **self._level_sel_kwargs)
+        self._xds = self.apply_slices(self._xds)
 
         # drop these because cftime gives trouble no matter what
         self._xds = self._xds.drop_vars(["cftime", "ftime"])

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -101,7 +101,6 @@ class Anemoi(Target):
         chunks: dict,
         store_path: str,
         rename: Optional[dict] = None,
-        slices: Optional[dict] = None,
         forcings: Optional[tuple | list] = None,
     ) -> None:
 
@@ -110,7 +109,6 @@ class Anemoi(Target):
             chunks=chunks,
             store_path=store_path,
             rename=rename,
-            slices=slices,
             forcings=forcings,
         )
 


### PR DESCRIPTION
1. Slices is now in sources, instead of targets, since:
  * it makes more sense to do this before handing off to any transformations (e.g. vertical regridding!)
  * this may reduce data transfers, e.g. in case of 1/4 degree replay
2. Addresses #34 by making this sorting an option, default to false, which is what anemoi-datasets does
3. fixes the new_level creation in vertical regridding (didn't know this was an issue)
