### PR TITLE
CLI Overwrite Flag

### DIFF
--- a/ufs2arco/cli.py
+++ b/ufs2arco/cli.py
@@ -11,9 +11,15 @@ def main():
         type=str,
         help="Path to the YAML recipe file.",
     )
+
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Pass this flag to overwrite an existing zarr store in the specified location",
+    )
     args = parser.parse_args()
 
-    Driver(args.yaml_file).run()
+    Driver(args.yaml_file).run(overwrite=args.overwrite)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Enable the following CLI flag

```
ufs2arco recipe.yaml --overwrite
```

is equivalent to

```
python -c "from ufs2arco.driver import Driver; Driver('recipe.yaml').run(overwrite=True)"
```

and omitting it retains the default value of overwrite=False.