### PR TITLE
Decode Timedelta

### DIFF
--- a/tests/integration/test_datasets.py
+++ b/tests/integration/test_datasets.py
@@ -101,7 +101,7 @@ def run_test(source, target):
     logger.info(f" ... Test Passed")
 
 def _test_static_vars(source, target, store):
-    ds = xr.open_zarr(store)
+    ds = xr.open_zarr(store, decode_timedelta=True)
 
     lsm = {
         "gefs": "lsm",
@@ -173,13 +173,13 @@ def test_this_combo(source, target):
 )
 @pytest.mark.parametrize("source", _sources)
 def test_flattened_base_equals_anemoi(source):
-    ds = xr.open_zarr(os.path.join(_local_path, source, "base", "dataset.zarr"))
+    ds = xr.open_zarr(os.path.join(_local_path, source, "base", "dataset.zarr"), decode_timedelta=True)
     if "pressure" in ds.dims:
         ds = ds.rename({"pressure": "level"})
     if "t0" in ds.dims:
         ds = ds.rename({"t0": "time"})
         ds = ds.sel(fhr=0, drop=True)
-    ads = xr.open_zarr(os.path.join(_local_path, source, "anemoi", "dataset.zarr"))
+    ads = xr.open_zarr(os.path.join(_local_path, source, "anemoi", "dataset.zarr"), decode_timedelta=True)
 
     for key in ds.data_vars:
 

--- a/ufs2arco/sources/cloud_zarr.py
+++ b/ufs2arco/sources/cloud_zarr.py
@@ -36,6 +36,7 @@ class CloudZarrData(Source):
         xds = xr.open_zarr(
             uri,
             storage_options={"token": "anon"},
+            decode_timedelta=True,
         )
         self._xds = xds.rename(self.rename)
 

--- a/ufs2arco/sources/noaa_grib_forecast.py
+++ b/ufs2arco/sources/noaa_grib_forecast.py
@@ -218,7 +218,7 @@ class NOAAGribForecastData:
             # handle lead_time/fhr coordinates
             xds = xds.expand_dims(["t0", "lead_time"])
             xds["fhr"] = xr.DataArray(
-                int(xds["lead_time"].values / 1e9 / 3600),
+                [int(lt / 1e9 / 3600) for lt in xds["lead_time"].values],
                 coords=xds["lead_time"].coords,
                 attrs={
                     "long_name": "hours since initial time",

--- a/ufs2arco/sources/noaa_grib_forecast.py
+++ b/ufs2arco/sources/noaa_grib_forecast.py
@@ -165,6 +165,7 @@ class NOAAGribForecastData:
             file,
             engine="cfgrib",
             filter_by_keys=self._filter_by_keys[varname],
+            decode_timedelta=True,
         )
         xda = xds[varname]
 


### PR DESCRIPTION
I'm getting the following warning

```
ufs2arco/sources/cloud_zarr.py:36: FutureWarning: In a future version of xarray decode_timedelta will default to False rather than None. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.
```

Which suggests we should specify that yes indeed we want the decode_timedelta set to true