### PR TITLE
Compute Temporal Residual Statistics

### DIFF
--- a/tests/integration/replay.anemoi.yaml
+++ b/tests/integration/replay.anemoi.yaml
@@ -11,6 +11,7 @@
 # - log mapping, with variables as a list
 # Target:
 # - base workflow for analysis
+# - compute temporal residual statistics
 # - forcings computation
 mover:
   name: datamover
@@ -62,6 +63,7 @@ transforms:
 
 target:
   name: anemoi
+  compute_temporal_residual_statistics: True
 
   forcings:
     - cos_latitude

--- a/ufs2arco/driver.py
+++ b/ufs2arco/driver.py
@@ -217,18 +217,15 @@ class Driver:
         topo.barrier()
         logger.info(f"Done moving the data\n")
 
-        if self.config["target"].get("name", "base") == "anemoi":
-            logger.info(f"Computing temporal increment statistics")
-            target._calc_temporal_increment_stats(topo)
-            logger.info(f"Done")
-
-
-
         logger.info(f"Aggregating statistics (if any specified for target)")
-        if topo.is_root:
-            target.aggregate_stats()
-        topo.barrier()
+        target.aggregate_stats(topo)
         logger.info(f"Done aggregating statistics\n")
+
+        compute_residual_stats = self.config["target"].get("name", "base") == "anemoi"
+        if target.compute_temporal_residual_statistics:
+            logger.info(f"Computing temporal residual statistics")
+            target._calc_temporal_increment_stats(topo)
+            logger.info(f"Done computing temporal residual statistics")
 
         logger.info(f"Storing the recipe and anything from the 'attrs' section in zarr store attributes")
         if topo.is_root:

--- a/ufs2arco/driver.py
+++ b/ufs2arco/driver.py
@@ -216,6 +216,14 @@ class Driver:
 
         topo.barrier()
         logger.info(f"Done moving the data\n")
+
+        if self.config["target"].get("name", "base") == "anemoi":
+            logger.info(f"Computing temporal increment statistics")
+            target._calc_temporal_increment_stats(topo)
+            logger.info(f"Done")
+
+
+
         logger.info(f"Aggregating statistics (if any specified for target)")
         if topo.is_root:
             target.aggregate_stats()

--- a/ufs2arco/driver.py
+++ b/ufs2arco/driver.py
@@ -221,10 +221,9 @@ class Driver:
         target.aggregate_stats(topo)
         logger.info(f"Done aggregating statistics\n")
 
-        compute_residual_stats = self.config["target"].get("name", "base") == "anemoi"
         if target.compute_temporal_residual_statistics:
             logger.info(f"Computing temporal residual statistics")
-            target._calc_temporal_increment_stats(topo)
+            target.calc_temporal_residual_stats(topo)
             logger.info(f"Done computing temporal residual statistics")
 
         logger.info(f"Storing the recipe and anything from the 'attrs' section in zarr store attributes")

--- a/ufs2arco/mpi.py
+++ b/ufs2arco/mpi.py
@@ -169,13 +169,13 @@ class SerialTopology:
     # we can assume these results already exist
     # this is just for code compatibility without mpi
     def sum(self, local_array, result_buffer):
-        result_buffer = local_array.copy()
+        result_buffer[:] = local_array
 
     def max(self, local_array, result_buffer):
-        result_buffer = local_array.copy()
+        result_buffer[:] = local_array
 
     def min(self, local_array, result_buffer):
-        result_buffer = local_array.copy()
+        result_buffer[:] = local_array
 
     def any(self, local_array, result_buffer):
-        result_buffer = local_array.copy()
+        result_buffer[:] = local_array

--- a/ufs2arco/mpi.py
+++ b/ufs2arco/mpi.py
@@ -95,6 +95,7 @@ class MPITopology:
         """
         self.comm.Barrier()
 
+
 class SerialTopology:
     """
     Looks and acts like the MPITopology, but works in cases when mpi is not importable.
@@ -114,6 +115,8 @@ class SerialTopology:
 
         self.root = 0
         self.pid = os.getpid()
+        self.size = 1
+        self.rank = 0
 
         self._init_log(log_dir=log_dir, level=log_level)
         logger.info(str(self))

--- a/ufs2arco/mpi.py
+++ b/ufs2arco/mpi.py
@@ -95,6 +95,21 @@ class MPITopology:
         """
         self.comm.Barrier()
 
+    def Reduce(self, local_array, result_buffer, op):
+        self.comm.Reduce(local_array, result_buffer, op=op, root=self.root)
+
+    def sum(self, local_array, result_buffer):
+        self.Reduce(local_array, result_buffer, op=MPI.SUM)
+
+    def max(self, local_array, result_buffer):
+        self.Reduce(local_array, result_buffer, op=MPI.MAX)
+
+    def min(self, local_array, result_buffer):
+        self.Reduce(local_array, result_buffer, op=MPI.MIN)
+
+    def any(self, local_array, result_buffer):
+        self.Reduce(local_array, result_buffer, op=MPI.LOR)
+
 
 class SerialTopology:
     """
@@ -149,3 +164,18 @@ class SerialTopology:
 
     def barrier(self) -> None:
         pass
+
+    # since the communication doesn't need to happen
+    # we can assume these results already exist
+    # this is just for code compatibility without mpi
+    def sum(self, local_array, result_buffer):
+        result_buffer = local_array.copy()
+
+    def max(self, local_array, result_buffer):
+        result_buffer = local_array.copy()
+
+    def min(self, local_array, result_buffer):
+        result_buffer = local_array.copy()
+
+    def any(self, local_array, result_buffer):
+        result_buffer = local_array.copy()

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -588,7 +588,7 @@ class Anemoi(Target):
             local_residual_variance = residual_variance.copy()
 
         logger.info(f"{self.name}.calc_temporal_residual_stats: Communicating results to root")
-        residual_variance = topo.sum(local_residual_variance, residual_variance)
+        topo.sum(local_residual_variance, residual_variance)
 
         logger.info(f"{self.name}.calc_temporal_residual_stats: ... done communicating")
 

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -113,6 +113,7 @@ class Anemoi(Target):
         store_path: str,
         rename: Optional[dict] = None,
         forcings: Optional[tuple | list] = None,
+        compute_temporal_residual_statistics: Optional[bool] = False,
         sort_channels_by_levels: Optional[bool] = False,
     ) -> None:
 
@@ -122,6 +123,7 @@ class Anemoi(Target):
             store_path=store_path,
             rename=rename,
             forcings=forcings,
+            compute_temporal_residual_statistics=compute_temporal_residual_statistics,
         )
 
         self.sort_channels_by_levels = sort_channels_by_levels
@@ -470,7 +472,7 @@ class Anemoi(Target):
         xds["sums_array"] = xds["data"].sum(dims, skipna=self.allow_nans).astype(np.float64)
         return xds
 
-    def aggregate_stats(self) -> None:
+    def aggregate_stats(self, topo) -> None:
         """Aggregate statistics over "time" and "ensemble" dimension...
         I'm assuming that this is relatively inexpensive without the spatial dimension
 
@@ -482,95 +484,132 @@ class Anemoi(Target):
         """
 
         xds = xr.open_zarr(self.store_path)
+        attrs = xds.attrs.copy()
 
-        # first load up the arrays
-        stat_vars = [
-            "count_array",
-            "has_nans_array",
-            "maximum_array",
-            "minimum_array",
-            "squares_array",
-            "sums_array",
-        ]
-        xds = xds[stat_vars]
-        xds = xds.load()
+        dims = ["time", "ensemble"]
+        time_indices = np.array_split(np.arange(len(xds["time"])), topo.size)
+        local_indices = time_indices[topo.rank]
 
-        logger.info(f"{self.name}.aggregate_stats: Loaded temporary stats arrays")
+        count = np.zeros_like(xds["variable"].values, dtype=xds["count_array"].dtype)
+        has_nans = np.full_like(xds["variable"].values, fill_value=False, dtype=xds["has_nans_array"].dtype)
+        maximum = np.full_like(xds["variable"].values, fill_value=-np.inf, dtype=xds["maximum_array"].dtype)
+        minimum = np.full_like(xds["variable"].values, fill_value=np.inf, dtype=xds["minimum_array"].dtype)
+        squares = np.zeros_like(xds["variable"].values, dtype=xds["squares_array"].dtype)
+        sums = np.zeros_like(xds["variable"].values, dtype=xds["sums_array"].dtype)
 
-        # the easy ones
-        xds["count"] = xds["count_array"].sum(["time", "ensemble"])
-        xds["has_nans"] = xds["has_nans_array"].any(["time", "ensemble"])
-        xds["maximum"] = xds["maximum_array"].max(["time", "ensemble"])
-        xds["minimum"] = xds["minimum_array"].min(["time", "ensemble"])
-        xds["squares"] = xds["squares_array"].sum(["time", "ensemble"])
-        xds["sums"] = xds["sums_array"].sum(["time", "ensemble"])
+        logger.info(f"{self.name}.aggregate_stats: Performing local computations")
+        if local_indices.size > 0:
 
-        # now add mean & stdev
-        xds["mean"] = xds["sums"] / xds["count"]
-        variance = xds["squares"] / xds["count"] - xds["mean"]**2
-        xds["stdev"] = xr.where(variance >= 0, np.sqrt(variance), 0.)
+            lds = xds.isel(time=local_indices)
+            local_count = lds["count_array"].sum(dims).compute().values
+            local_has_nans = lds["has_nans_array"].any(dims).compute().values
+            local_maximum = lds["maximum_array"].max(dims).compute().values
+            local_minimum = lds["minimum_array"].min(dims).compute().values
+            local_squares = lds["squares_array"].sum(dims).compute().values
+            local_sums = lds["sums_array"].sum(dims).compute().values
 
-        # ...and now we deal with the dates issue
-        # for some reason, it is a challenge to get the datetime64 dtype to open
-        # consistently between zarr and xarray, and
-        # it is much easier to deal with this all at once here
-        # than in the create_container and incrementally fill workflow.
-        xds["dates"] = xr.DataArray(
-            self.datetime,
-            coords=xds.time.coords,
-        )
-        xds["dates"].encoding = {
-            "dtype": "datetime64[s]",
-            "units": "seconds since 1970-01-01",
-        }
+        else:
 
-        # store it
-        xds.to_zarr(self.store_path, mode="a")
-        logger.info(f"{self.name}.aggregate_stats: Stored aggregated stats")
+            local_count = count.copy()
+            local_has_nans = has_nans.copy()
+            local_maximum = maximum.copy()
+            local_minimum = minimum.copy()
+            local_squares = squares.copy()
+            local_sums = sums.copy()
 
-        # now remove the temp versions
-        zds = zarr.open(self.store_path, mode="a")
-        for key in [
-            "count_array",
-            "has_nans_array",
-            "maximum_array",
-            "minimum_array",
-            "squares_array",
-            "sums_array",
-        ]:
-            logger.info(f"{self.name}.aggregate_stats: Removing temporary version {key}")
-            del zds[key]
-        zarr.consolidate_metadata(self.store_path)
+
+        # reduce results
+        logger.info(f"{self.name}.aggregate_stats: Communicating results to root")
+        if "MPI" in topo.__class__.__name__:
+            topo.comm.Reduce(local_count, count, op=MPI.SUM, root=topo.root)
+            topo.comm.Reduce(local_has_nans, has_nans, op=MPI.LOR, root=topo.root)
+            topo.comm.Reduce(local_maximum, maximum, op=MPI.MAX, root=topo.root)
+            topo.comm.Reduce(local_minimum, minimum, op=MPI.MIN, root=topo.root)
+            topo.comm.Reduce(local_squares, squares, op=MPI.SUM, root=topo.root)
+            topo.comm.Reduce(local_sums, sums, op=MPI.SUM, root=topo.root)
+
+        else:
+            count = local_count
+            has_nans = local_has_nans
+            maximum = local_maximum
+            minimum = local_minimum
+            squares = local_squares
+            sums = local_sums
+
+        logger.info(f"{self.name}.aggregate_stats: ... done communicating")
+
+        # the rest is done on the root rank
+        if topo.is_root:
+            nds = xr.Dataset()
+            nds["count"] = xr.DataArray(count, coords=xds.variable.coords)
+            nds["has_nans"] = xr.DataArray(has_nans, coords=xds.variable.coords)
+            nds["maximum"] = xr.DataArray(maximum, coords=xds.variable.coords)
+            nds["minimum"] = xr.DataArray(minimum, coords=xds.variable.coords)
+            nds["squares"] = xr.DataArray(squares, coords=xds.variable.coords)
+            nds["sums"] = xr.DataArray(sums, coords=xds.variable.coords)
+
+            # now add mean & stdev
+            nds["mean"] = nds["sums"] / nds["count"]
+            variance = nds["squares"] / nds["count"] - nds["mean"]**2
+            nds["stdev"] = xr.where(variance >= 0, np.sqrt(variance), 0.)
+
+            # ...and now we deal with the dates issue
+            # for some reason, it is a challenge to get the datetime64 dtype to open
+            # consistently between zarr and xarray, and
+            # it is much easier to deal with this all at once here
+            # than in the create_container and incrementally fill workflow.
+            nds["dates"] = xr.DataArray(
+                self.datetime,
+                coords=xds.time.coords,
+            )
+            nds["dates"].encoding = {
+                "dtype": "datetime64[s]",
+                "units": "seconds since 1970-01-01",
+            }
+
+            # store it, first copying the attributes over
+            nds.attrs = attrs
+            nds.to_zarr(self.store_path, mode="a")
+            logger.info(f"{self.name}.aggregate_stats: Stored aggregated stats")
+
+        # unclear if this barrier is necessary...
+        topo.barrier()
+
 
     def _calc_temporal_increment_stats(self, topo):
 
         xds = xr.open_zarr(self.store_path)
-        time_indices = np.array_split(np.arange(len(xds["time"])), topo.size)
+        attrs = xds.attrs.copy()
+
+        data_diff = xds["data"].diff("time")
+        n_time = len(data_diff["time"])
+        time_indices = np.array_split(np.arange(len(data_diff["time"])), topo.size)
         local_indices = time_indices[topo.rank]
 
         if local_indices.size > 0:
-            logger.info(f"{self.name}.calc_temporal_increment_stats: Computing temporal diff on rank {topo.rank}")
             mdims = [d for d in xds["data"].dims if d not in ("variable", "time")]
-            lds = xds.isel(time=local_indices)
-            local_residual_variance = (lds["data"].diff("time")**2).mean(mdims).sum("time").compute()
-            local_count = len(lds.time)
+            local_data_diff = data_diff.isel(time=local_indices)
+            local_residual_variance = (local_data_diff**2).mean(mdims).sum("time").compute()
+            local_residual_variance /= n_time
         else:
             local_residual_variance = xr.zeros_like(xds["variable"])
-            local_count = 0
 
-        logger.info(f"{self.name}.calc_temporal_increment_stats: reduce 1")
-        residual_variance = topo.comm.reduce(local_residual_variance, op=MPI.SUM, root=topo.root)
-        logger.info(f"{self.name}.calc_temporal_increment_stats: reduce 2")
-        global_count = topo.comm.reduce(local_count, op=MPI.SUM, root=topo.root)
-
-        nds = xr.Dataset()
-        nds["residual_stdev"] = np.sqrt(residual_variance / global_count)
-
-        # compute geomtric mean by log-exp trick (since scipy isn't a dependency to ufs2arco)
-        denominator = np.exp(np.log(xds["residual_stdev"]).mean("variable"))
-        nds["gmean_residual_stdev"] = xds["residual_stdev"] / denominator
+        logger.info(f"{self.name}.calc_temporal_increment_stats: aggregating local computations")
+        residual_variance = topo.sum(local_residual_variance)
 
         if topo.is_root:
-            logger.info(f"{self.name}.calc_temporal_increment_stats: storing temporal stats")
+            nds = xr.Dataset()
+            nds.attrs = attrs
+            nds["residual_stdev"] = np.sqrt(residual_variance)
+
+            # compute geomtric mean by log-exp trick (since scipy isn't a dependency to ufs2arco)
+            # ignore 0 values, since this is probably from static variables
+            rstdev = nds["residual_stdev"].where(nds["residual_stdev"] > 0)
+            denominator = np.exp(np.log(rstdev).mean("variable").values)
+            nds["gmean_residual_stdev"] = nds["residual_stdev"] / denominator
+
             nds.to_zarr(self.store_path, mode="a")
+            logger.info(f"{self.name}.calc_temporal_increment_stats: stored temporal stats")
+
+        # unclear if this barrier is necessary
         topo.barrier()

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -564,7 +564,7 @@ class Anemoi(Target):
         topo.barrier()
 
 
-    def _calc_temporal_increment_stats(self, topo):
+    def calc_temporal_residual_stats(self, topo):
 
         xds = xr.open_zarr(self.store_path)
         attrs = xds.attrs.copy()

--- a/ufs2arco/targets/base.py
+++ b/ufs2arco/targets/base.py
@@ -60,6 +60,7 @@ class Target:
         store_path: str,
         rename: Optional[dict] = None,
         forcings: Optional[list | tuple] = None,
+        compute_temporal_residual_statistics: Optional[bool] = False,
     ) -> None:
         """
         Initialize the GEFSDataset object.
@@ -69,6 +70,7 @@ class Target:
             chunks (dict): Dictionary with chunk sizes for Dask arrays.
             store_path (str): Path to store the output data.
             rename (dict, optional): rename variables
+            compute_temporal_residual_statistics: (bool, optional): if True, compute statistics of the temporal difference
         """
         self.source = source
         self.store_path = store_path
@@ -97,6 +99,12 @@ class Target:
             self.forcings = forcings
         else:
             self.forcings = tuple()
+
+        # temporal residual statistics
+        # For now, only implemented in anemoi target
+        if "anemoi" not in self.name.lower() and compute_temporal_residual_statistics:
+            raise NotImplementedError(f"{self.name}.__init__: computation of temporal residual statistics not implemented for this target")
+        self.compute_temporal_residual_statistics = compute_temporal_residual_statistics
 
         logger.info(str(self))
 

--- a/ufs2arco/targets/base.py
+++ b/ufs2arco/targets/base.py
@@ -207,8 +207,11 @@ class Target:
         xds = self.source.add_full_extra_coords(xds)
         return xds
 
-    def aggregate_stats(self) -> None:
+    def aggregate_stats(self, topo) -> None:
         """Aggregate statistics over "time" and "ensemble" dimension...
         This should read in the zarr store, aggregate stats, and delete any temporary arrays from the zarr store
         """
+        pass
+
+    def calc_temporal_residual_stats(self, topo) -> None:
         pass


### PR DESCRIPTION
Compute temporal residual statistics as in ACE. Adds an optional flag to turn this on, otherwise it's false.

Also, speed up the statistics aggregation code... that was taking way too long:
* Required loading things in, which is fine memory wise, but slow with long time arrays
* It appended the full dataset back onto itself, which... is just a bad idea. Here we make a new one and append that.

TODO:
- [x] Check over base/anemoi integration
- [x] Verify values with main branch
- [x] Verify new MPI statistics and temporal with those computed brute force