### PR TITLE
Pin NumPy version for Numba

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
     - python=3.11
 # Base dependencies
-    - numpy
+    - numpy<2.3
     - xarray
     - cf_xarray
     - cftime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {file = "LICENSE.txt"}
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "numpy",
+    "numpy<2.3",
     "xarray",
     "cf_xarray",
     "cftime",


### PR DESCRIPTION
See https://github.com/numba/numba/issues/10105

In order to move forward right now, pin numpy<2.3 until this gets resolved