### PR TITLE
Fix Double Precision Issue

### DIFF
--- a/ufs2arco/sources/noaa_grib_forecast.py
+++ b/ufs2arco/sources/noaa_grib_forecast.py
@@ -137,7 +137,7 @@ class NOAAGribForecastData:
                         f"{self.name}: Could not find {varname}\n\t" +
                         f"dims = {dims}, file_suffixes = {self._varmeta[varname]['file_suffixes']}"
                     )
-                    dsdict[varname] = xr.DataArray(name=varname)
+                    dsdict[varname] = xr.DataArray(name=varname, dtype=np.float32)
         xds = xr.Dataset(dsdict)
         xds = self.apply_slices(xds)
         return xds
@@ -221,7 +221,7 @@ class NOAAGribForecastData:
                 if len(level_selection) == 0:
                     # we don't select vertical levels available in this file
                     # return an empty data array
-                    return xr.DataArray(name=varname)
+                    return xr.DataArray(name=varname, dtype=xda.dtype)
                 xds = xds.sel(level=level_selection, **self._level_sel_kwargs)
 
             # handle potential ensemble member dimension


### PR DESCRIPTION
Closes #77 

Some variables with GFS were being created at double precision, even though the data is only single precision.

This was happening because GFS has the two grib files for "primary" and "secondary" variables 🙄 , where we always have to look into both files since the variables and levels are inconsistently scattered between the two over time. If we looked into the secondary file but didn't actually need anything there, I was creating a dummy array to be easily merged with the data from the primary file. Well, the dummy array was created as a double precision NaN, causing the merged result to be double precision.

This PR fixes the issue by creating a dummy array either default to single precision (if we had trouble finding that file) or by inheriting the original file dtype (if we found something but didn't need it). This issue could arise with GEFS data, or HRRR data if we end up needing multiple grib files, so better it's fixed now...

Note that this dummy array is created instead of `None` in order to indicate that nothing bad is happening - we just didn't need that data.