### PR TITLE
Bugfix: Catch All Grib Errors (Hopefully)

### DIFF
--- a/ufs2arco/sources/noaa_grib_forecast.py
+++ b/ufs2arco/sources/noaa_grib_forecast.py
@@ -197,8 +197,8 @@ class NOAAGribForecastData:
                 filter_by_keys=fbk,
                 decode_timedelta=True,
             )
-        except gribapi.errors.WrongLengthError:
-            logger.warning(f"{self.name}: gribapi.errors.WrongLengthError for varname = {varname} at dims = {dims}")
+        except gribapi.errors.GribInternalError as e:
+            logger.warning(f"{self.name}: {type(e)} for varname = {varname} at dims = {dims}")
             return None
 
         if "original_name" in self._varmeta[varname]:


### PR DESCRIPTION
Yet another addition to #83 ...

This generalizes the line

https://github.com/NOAA-PSL/ufs2arco/blob/b6822f4b4d3bef7c32e0b8cbb8bdebc7ccbfe588/ufs2arco/sources/noaa_grib_forecast.py#L200-L202

to instead catch any gribapi error... at least according to gemini.