### PR TITLE
Minor update backlog

### DIFF
--- a/ufs2arco/mpi.py
+++ b/ufs2arco/mpi.py
@@ -153,6 +153,8 @@ class SerialTopology:
         self.log_dir = log_dir
 
         logger.setLevel(level=level)
+        logger.handlers.clear()
+        logger.propagate = False
         formatter = SimpleFormatter(fmt="[%(relativeCreated)d s] [%(levelname)-7s] %(message)s")
         if log_dir is None:
             # if no dir is provided, flush to stdout

--- a/ufs2arco/transforms/horizontal_regrid.py
+++ b/ufs2arco/transforms/horizontal_regrid.py
@@ -32,7 +32,10 @@ def horizontal_regrid(
     ds_out = xr.open_dataset(os.path.expandvars(target_grid_path), **kw)
 
     # required for xesmf
-    xds = xds.rename({"longitude": "lon", "latitude": "lat"})
+    rename = {"longitude": "lon", "latitude": "lat"}
+    for key, val in rename.items():
+        if key in xds:
+            xds = xds.rename({key: val})
 
     # for the first time, we have to compute the regridder weights no matter what
     # so, figure out if we have the file or not


### PR DESCRIPTION
These have been sitting around for a while but should be useful.

* transforms/horizontal_regrid updates: the updates here make the renaming code block more transferable. Originally it was assumed that all incoming datasets have the naming convention used internally by ufs2arco (fully spelled out latitude and longitude) which needs to be renamed for xesmf. By adding in this code block, the function is more easily importable elsewhere (e.g. eagle-tools).
* the logger bit is... maybe useful? It was recommended at some point. I haven't noticed performance differences, but all behavior is the same, so plopping it in.