### PR TITLE
Anemoi target with remapped horizontal dimensions

### DIFF
--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -178,7 +178,7 @@ class Anemoi(Target):
                 self.rename.pop(key)
 
         self.variables_with_nans = variables_with_nans
-        self.transformed_dims = transformed_dims
+        self.transformed_dims = transformed_dims if transformed_dims else {}
 
 
     def apply_transforms_to_sample(

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -359,6 +359,12 @@ class Anemoi(Target):
                     stack_order = list(d for d in xds[name].dims if d in self.expanded_horizontal_dims)
                     nds.attrs["stack_order"] = stack_order
                     nds.attrs["field_shape"] = list(len(xds[d]) for d in stack_order)
+                elif not any(d in xds[name].dims for d in self.expanded_horizontal_dims):
+                    msg = f"Could not find any expected horizontal dimensions {self.expanded_horizontal_dims} within the dataset\n"
+                    msg += f"if regridding was performed and the horizontal dimensions are renamed (e.g., latitude -> y or longitude -> x)\n"
+                    msg += f"then provide this information as a dictionary in the 'target' section of the configuration yaml\n"
+                    msg += "e.g. {'latitude': 'y', 'longitude': 'x'}"
+                    raise KeyError(msg)
 
         return nds
 

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -51,7 +51,12 @@ class Anemoi(Target):
 
     @property
     def expanded_horizontal_dims(self):
-        return tuple(self.protected_rename.get(d, d) for d in self.source.horizontal_dims)
+        # First, get the original source dimensions, with any renaming due to regridding, or other transformation operations
+        # based on explicit user provided information
+        ehd = tuple(self.transformed_dims.get(d, d) for d in self.source.horizontal_dims)
+
+        # Now do the protected renaming, which manages anemoi specific stuff
+        return tuple(self.protected_rename.get(d, d) for d in ehd)
 
     @property
     def horizontal_dims(self):
@@ -140,7 +145,14 @@ class Anemoi(Target):
         compute_temporal_residual_statistics: Optional[bool] = False,
         sort_channels_by_levels: Optional[bool] = False,
         variables_with_nans: Optional[list] = None,
+        transformed_dims: Optional[dict] = None,
     ) -> None:
+        """
+
+        Args:
+            ... the rest of the docs ...
+            transformed_dims (dict, optional): if your dataset gets regridded to have new dimension names, e.g. from latitude/longitude to a curvilinear grid with y/x coordinates (in the case of GFS -> HRRR grid), we need to explicitly tell the target class about this transformation, so it knows how to handle horizontal dimensions, since horizontal dimensions are always different. So this would be based on dimension order e.g. {'latitude': 'y', 'longitude': 'x'}
+        """
 
         super().__init__(
             source=source,
@@ -166,11 +178,7 @@ class Anemoi(Target):
                 self.rename.pop(key)
 
         self.variables_with_nans = variables_with_nans
-
-
-    def get_expanded_dim_order(self, xds):
-        """this is used in :meth:`map_static_to_expanded`"""
-        return ("time", "ensemble") + tuple(xds.attrs["stack_order"])
+        self.transformed_dims = transformed_dims
 
 
     def apply_transforms_to_sample(

--- a/ufs2arco/targets/anemoi.py
+++ b/ufs2arco/targets/anemoi.py
@@ -359,12 +359,6 @@ class Anemoi(Target):
                     stack_order = list(d for d in xds[name].dims if d in self.expanded_horizontal_dims)
                     nds.attrs["stack_order"] = stack_order
                     nds.attrs["field_shape"] = list(len(xds[d]) for d in stack_order)
-                elif not any(d in xds[name].dims for d in self.expanded_horizontal_dims):
-                    msg = f"Could not find any expected horizontal dimensions {self.expanded_horizontal_dims} within the dataset\n"
-                    msg += f"if regridding was performed and the horizontal dimensions are renamed (e.g., latitude -> y or longitude -> x)\n"
-                    msg += f"then provide this information as a dictionary in the 'target' section of the configuration yaml\n"
-                    msg += "e.g. {'latitude': 'y', 'longitude': 'x'}"
-                    raise KeyError(msg)
 
         return nds
 


### PR DESCRIPTION
The anemoi target needs to know the horizontal dimensions of the dataset in order to stack data properly and store the information as an attribute, which is used in downstream applications. This is straightforward for most cases, but becomes tricky when the horizontal dimensions get remapped. For example, when regridding GFS data onto the HRRR grid, the horizontal dimensions (latitude, longitude) get remapped to the curvilinear indices (y, x). The Anemoi target needs to know about this, and there is really no way to know this information from the code alone, since the user could transform the horizontal dimensions into anything they want to. So, we handle this by requiring the user to provide this information in the target section:

```yaml
target:
  name: anemoi
  transformed_dims: 
    latitude: y
    longitude: x
...
```

Note that I've not run into this before even though I've been evaluating GFS on the HRRR domain because the "base" target is passive, it doesn't need to know anything about the horizontal dimensions, except for the chunk names.